### PR TITLE
fixing chained classnames

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default function attacher ({include, exclude} = {}) {
             'hljs',
             ...data.hProperties.className || [],
             `language-${lang}`,
-        ];
+        ].join(' ')
     }
 
     return ast => visit(ast, 'code', visitor);

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default function attacher ({include, exclude} = {}) {
             'hljs',
             ...data.hProperties.className || [],
             `language-${lang}`,
-        ].join(' ')
+        ].join(' ');
     }
 
     return ast => visit(ast, 'code', visitor);


### PR DESCRIPTION
Fixing a bug in which classnames are passed through as an array, which cause them to join with `,` resulting in invalid classnames

<img width="315" alt="conjure_docs" src="https://user-images.githubusercontent.com/52420/40340868-7037931a-5d36-11e8-9cb9-c8e854080d0d.png">
